### PR TITLE
update bash completion

### DIFF
--- a/get-started/initialize/step2.md
+++ b/get-started/initialize/step2.md
@@ -10,7 +10,5 @@
 **Optional:** Install bash completion for `dvc`:
 
 ```
-dvc completion -s bash > /etc/bash_completion.d/dvc
+dvc completion -s bash | sudo tee /etc/bash_completion.d/dvc
 ```{{execute}}
-
-`source /etc/bash_completion`{{execute}}

--- a/get-started/initialize/step2.md
+++ b/get-started/initialize/step2.md
@@ -12,3 +12,5 @@
 ```
 dvc completion -s bash | sudo tee /etc/bash_completion.d/dvc
 ```{{execute}}
+
+`source /etc/bash_completion`{{execute}}


### PR DESCRIPTION
Although the existing command works in [katacoda](https://www.katacoda.com/dvc/courses/get-started/initialize), I think it would be a great idea to align all the commands with the [docs](https://dvc.org/doc/install/completion#bash-completion-on-debianubuntu).
I was following the katacoda tutorials, and for some reason, the shell completion command worked on the katacoda terminal but not on my Ubuntu PC.(Although even the Katacoda terminal uses Ubuntu). 

But the command specified in the docs did work.

Just a potential improvement. :v: 