### PR TITLE
Initialize scenario: add explanation to some commands

### DIFF
--- a/get-started/initialize/step3.md
+++ b/get-started/initialize/step3.md
@@ -1,7 +1,7 @@
 # Initialize DVC
 
 `dvc init` creates a new `.dvc/` directory for internal configuration and cache
-files
+files:
 
 `dvc init`{{execute}}
 

--- a/get-started/initialize/step3.md
+++ b/get-started/initialize/step3.md
@@ -1,17 +1,21 @@
 # Initialize DVC
 
+`dvc init` creates a new `.dvc/` directory for internal configuration and cache
+files
+
 `dvc init`{{execute}}
 
 `tree -a -I .git`{{execute}}
 
+The directory is automatically staged on git:
+
 `git status -s`{{execute}}
+
+Some files and folders are automatically added to `.gitignore`:
 
 `cat .dvc/.gitignore`{{execute}}
 
 `cat .dvc/config`{{execute}}
-
-The directory `.dvc` keeps cached files, configuration, and other DVC
-meta files.
 
 ```
 git commit \

--- a/get-started/initialize/step3.md
+++ b/get-started/initialize/step3.md
@@ -1,7 +1,6 @@
 # Initialize DVC
 
-`dvc init` creates a new `.dvc/` directory for internal configuration and cache
-files
+`dvc init` creates a new `.dvc/` directory for internal configuration and cache files
 
 `dvc init`{{execute}}
 
@@ -15,6 +14,7 @@ Some files and folders are automatically added to `.gitignore`:
 
 `cat .dvc/.gitignore`{{execute}}
 
+`<!---` should `dvc init` add something to `config` file? `--->`
 `cat .dvc/config`{{execute}}
 
 ```

--- a/get-started/initialize/step3.md
+++ b/get-started/initialize/step3.md
@@ -1,6 +1,7 @@
 # Initialize DVC
 
-`dvc init` creates a new `.dvc/` directory for internal configuration and cache files
+`dvc init` creates a new `.dvc/` directory for internal configuration and cache
+files
 
 `dvc init`{{execute}}
 


### PR DESCRIPTION
Hi all, 
I'm reviewing the Katacoda courses to check if everything is aligned with DVC 1.0 release.
**Everything is fine** on this scenario, I've just added some explanations to step3 commands.

**Question**
Should `dvc init` write something to `.dvc/config` file? 
I don't think so but I'm asking to see if there's a problem with the katacoda environment (the file is empty).
If this is indeed the desired behavior I think we can remove this `cat .dvc/config` [line](https://github.com/dmesquita/katacoda-scenarios/blame/160572374d47f49762ab66a958b33c5672beec1c/get-started/initialize/step3.md#L11)