### PR TITLE
Updates Outdated Scenarios (Pipelines, Experiments) to use dvc run -n

### DIFF
--- a/get-started/experiments/assets/prepare.sh
+++ b/get-started/experiments/assets/prepare.sh
@@ -39,7 +39,7 @@ set -o verbose
 :; wget -q https://code.dvc.org/get-started/code.zip
 :; unzip code.zip
 :; rm code.zip
-:; git add src/
+:; git add params.yaml src/
 :; git commit -m "Add source code files to repo"
 
 ### Install python requirements
@@ -52,22 +52,22 @@ set -o verbose
 :; git add .gitignore
 :; git commit -m "Ignore virtualenv directory"
 
-### Stage: prepare.dvc
+### Stage: prepare
 :; dvc run \
-       -f prepare.dvc \
+       -n prepare \
        -d src/prepare.py \
        -d data/data.xml \
        -o data/prepared \
        python \
            src/prepare.py \
            data/data.xml
-:; git add data/.gitignore prepare.dvc
+:; git add data/.gitignore dvc.yaml dvc.lock
 :; git commit -m "Create data preparation stage"
 :; dvc push -q
 
-### Stage: featurize.dvc
+### Stage: featurize
 :; dvc run \
-       -f featurize.dvc \
+       -n featurize \
        -d src/featurization.py \
        -d data/prepared \
        -o data/features \
@@ -75,11 +75,11 @@ set -o verbose
            src/featurization.py \
            data/prepared \
            data/features
-:; git add data/.gitignore featurize.dvc
+:; git add data/.gitignore dvc.yaml dvc.lock
 
-### Stage: train.dvc
+### Stage: train
 :; dvc run \
-       -f train.dvc \
+       -n train \
        -d src/train.py \
        -d data/features \
        -o model.pkl \
@@ -87,13 +87,13 @@ set -o verbose
            src/train.py \
            data/features \
            model.pkl
-:; git add .gitignore train.dvc
+:; git add data/.gitignore dvc.yaml dvc.lock
 :; git commit -m "Create featurization and training stages"
 :; dvc push -q
 
 ### Reproducing the model
 :; sed -i data/data.xml -e '1d'
-:; dvc repro -q train.dvc
+:; dvc repro
 :; git add .
 :; git commit -m "Produced another version of model.pkl"
 :; dvc push -q

--- a/get-started/experiments/step1.md
+++ b/get-started/experiments/step1.md
@@ -11,38 +11,44 @@ Let's add an evaluation stage to the pipeline:
 
 ```
 dvc run \
-    -f evaluate.dvc \
+    -n evaluate \
     -d src/evaluate.py \
     -d model.pkl \
     -d data/features \
-    -M auc.metric \
+    -M scores.json \
+    --plots-no-cache prc.json \
     python \
         src/evaluate.py \
         model.pkl \
         data/features \
-        auc.metric
+        scores.json \
+        prc.json
 ```{{execute}}
 
 The evaluation command calculates an AUC value using the test
 dataset. It reads features from the `data/features/test.pkl` file and
-produces the metric file `auc.metric`, which is marked by the option
+produces the metric file `scores.json`, which is marked by the option
 `-M`.  This option tells the stage to not store the metrics file in
 cache; since it is just a small text file we can track it with Git. If
 we wanted to store it in the DVC cache instead, we would have used the
-option `-m` (lowercase).
+option `-m` (lowercase). It also writes precision, recall, and thresholds arrays into plots file `prc.json`, which is marked by the option `--plots-no-cache` emphasizing that this file should not get cached (similar to the metrics file, `scores.json`). Alternatively, we would have used the option `--plots` if we wanted to store it in the DVC cache.
 
 `git status -s`{{execute}}
 
-`cat evaluate.dvc`{{execute}}
+`cat dvc.yaml`{{execute}}
 
-`cat auc.metric`{{execute}}
+`cat scores.json`{{execute}}
 
 `dvc metrics show`{{execute}}
+
+`cat prc.json`{{execute}}
+
+`dvc plots show`{{execute}}
 
 Let's get another snapshot of the project by committing changes to
 Git:
 
-`git add evaluate.dvc auc.metric`{{execute}}
+`git add dvc.yaml dvc.lock scores.json prc.json`{{execute}}
 
 `git commit -m "Create evaluation stage"`{{execute}}
 

--- a/get-started/experiments/step2.md
+++ b/get-started/experiments/step2.md
@@ -3,22 +3,20 @@
 Let's say that now we want to try a modified feature extraction.  Edit
 `src/featurization.py` to enable bigrams and increase the number of
 features. Open it with a text editor (`vim` or `nano`) and set
-`max_features=6000` and `ngram_range=(1, 2)` in `CountVectorizer`.
+`max_features = 6000` and `ngrams = 2` in global variables at the top (lines 28-29).
 
 It should look like this:
 
 ```
-bag_of_words = CountVectorizer(
-    stop_words='english',
-    max_features=6000,
-    ngram_range=(1, 2))
+max_features = 6000
+ngrams = 2
 ```
 
 This `sed` command does the modification automatically:
 
 ```
 sed -i src/featurization.py \
-    -e 's/max_features.*/max_features=6000, ngram_range=(1, 2))/'
+    -e 's/max_features = params.*/max_features = 6000/; s/ngrams = params.*/ngrams = 2/'
 ```{{execute}}
 
 `git status -s`{{execute}}
@@ -29,14 +27,14 @@ sed -i src/featurization.py \
 
 Try to reproduce the last stage:
 
-`dvc repro evaluate.dvc`{{execute}}
+`dvc repro evaluate`{{execute}}
 
-Notice that it will reproduce the stages `featurize.dvc`,
-`train.dvc` and `evaluate.dvc`.
+Notice that it will reproduce the stages `featurize`,
+`train` and `evaluate`.
 
 `dvc status`{{execute}}
 
-`dvc repro evaluate.dvc`{{execute}}
+`dvc repro evaluate`{{execute}}
 
 `dvc metrics show`{{execute}}
 

--- a/get-started/pipelines/assets/prepare.sh
+++ b/get-started/pipelines/assets/prepare.sh
@@ -39,7 +39,7 @@ set -o verbose
 :; wget -q https://code.dvc.org/get-started/code.zip
 :; unzip code.zip
 :; rm code.zip
-:; git add src/
+:; git add params.yaml src/
 :; git commit -m "Add source code files to repo"
 
 ### Install python requirements
@@ -52,15 +52,15 @@ set -o verbose
 :; git add .gitignore
 :; git commit -m "Ignore virtualenv directory"
 
-### Stage: prepare.dvc
+### Stage: prepare
 :; dvc run \
-       -f prepare.dvc \
+       -n prepare \
        -d src/prepare.py \
        -d data/data.xml \
        -o data/prepared \
        python \
            src/prepare.py \
            data/data.xml
-:; git add data/.gitignore prepare.dvc
+:; git add data/.gitignore dvc.yaml dvc.lock
 :; git commit -m "Create data preparation stage"
 :; dvc push -q

--- a/get-started/pipelines/step1.md
+++ b/get-started/pipelines/step1.md
@@ -11,7 +11,7 @@ Let's create another stage for it:
 
 ```
 dvc run \
-    -f featurize.dvc \
+    -n featurize \
     -d src/featurization.py \
     -d data/prepared \
     -o data/features \
@@ -23,12 +23,12 @@ dvc run \
 
 `git status -s`{{execute}}
 
-`git diff data/.gitignore`{{execute}}
+`git diff data/.gitignore dvc.yaml`{{execute}}
 
 `ls -lh data/features/`{{execute}}
 
-`cat featurize.dvc`{{execute}}
+`cat dvc.yaml`{{execute}}
 
 Add changes to Git:
 
-`git add data/.gitignore featurize.dvc`{{execute}}
+`git add data/.gitignore dvc.yaml dvc.lock`{{execute}}

--- a/get-started/pipelines/step2.md
+++ b/get-started/pipelines/step2.md
@@ -11,7 +11,7 @@ Let's add another stage for it:
 
 ```
 dvc run \
-    -f train.dvc \
+    -n train \
     -d src/train.py \
     -d data/features \
     -o model.pkl \
@@ -23,15 +23,15 @@ dvc run \
 
 `git status -s`{{execute}}
 
-`git diff .gitignore`{{execute}}
+`git diff .gitignore dvc.yaml`{{execute}}
 
 `ls -lh model.pkl`{{execute}}
 
-`cat train.dvc`{{execute}}
+`cat dvc.yaml`{{execute}}
 
 Add changes to Git and commit:
 
-`git add .gitignore train.dvc`{{execute}}
+`git add .gitignore dvc.yaml dvc.lock`{{execute}}
 
 `git status -s`{{execute}}
 

--- a/get-started/pipelines/step3.md
+++ b/get-started/pipelines/step3.md
@@ -2,16 +2,6 @@
 
 Let's see the pipeline that we have built so far:
 
-`dvc pipeline show train.dvc`{{execute}}
+`dvc dag`{{execute}}
 
-`dvc pipeline show train.dvc --ascii`{{execute}}
-
-```
-dvc pipeline show train.dvc \
-    --ascii --commands
-```{{execute}}
-
-```
-dvc pipeline show train.dvc \
-    --ascii --outs
-```{{execute}}
+`dvc dag --dot`{{execute}}

--- a/get-started/pipelines/step4.md
+++ b/get-started/pipelines/step4.md
@@ -4,7 +4,7 @@ Let's use the pipeline to produce `model.pkl` again:
 
 `dvc status`{{execute}}
 
-`dvc repro train.dvc`{{execute}}
+`dvc repro`{{execute}}
 
 Since nothing has changed and all the outputs are up to date, there is
 nothing to be executed and nothing to be reproduced.
@@ -16,17 +16,17 @@ happens:
 
 `dvc status`{{execute}}
 
-`dvc repro train.dvc`{{execute}}
+`dvc repro`{{execute}}
 
-- Since we changed the data file, the stage `prepare.dvc` was rerun
+- Since we changed the data file, the stage `prepare` was rerun
   and its outputs changed (in directory `data/prepared/`).
 
-- But `data/prepared` is a dependency of `featurize.dvc`, so this
+- But `data/prepared` is a dependency of `featurize`, so this
   stage was rerun as well and its outputs changed (in directory
   `data/features/`).
 
 - Finally, directory `data/features` is a dependency of the stage
-  `train.dvc`, so this stage was rerun and `model.pkl` was reproduced.
+  `train`, so this stage was rerun and `model.pkl` was reproduced.
 
 Along the way, `dvc repro` has saved to cache all the changed
 dependencies and outputs of the stages, and `dvc status` confirms
@@ -34,7 +34,7 @@ that everything is up to date with the cache:
 
 `dvc status`{{execute}}
 
-`dvc repro train.dvc`{{execute}}
+`dvc repro`{{execute}}
 
 As a result, `dvc repro` does not have to rerun anything.
 
@@ -42,7 +42,7 @@ As a result, `dvc repro` does not have to rerun anything.
 
 `git diff`{{execute}}
 
-However the stage files (`*.dvc`) are now pointing to new versions of
+However `data/data.xml.dvc` and `dvc.lock` are now pointing to new versions of
 cached files (indicated by the changed MD5 hashes of dependencies and
 outputs). We should take a snapshot of the current state of the
 project by committing them to git:


### PR DESCRIPTION
As explained in Issue #18, scenarios `Pipelines` and `Experiments` are not being initialized properly on katacoda, primarily due to the outdated use of `dvc run` (especially with using the flag `-f`)

This PR updates the 
1. initialization script `prepare.sh` and 
2. instructions `*.md`
in these two scenarios to make them compatible with the latest versions of `dvc`