### PR TITLE
Renamed containers to dvcorg versions (#56)

### DIFF
--- a/get-started/02-versioning/install.sh
+++ b/get-started/02-versioning/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CONTAINER="emresult/katacoda-gs-versioning"
+export CONTAINER="dvcorg/doc-katacoda:start-versioning"
 
 docker volume create example-get-started
 

--- a/get-started/03-accessing/install.sh
+++ b/get-started/03-accessing/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CONTAINER="emresult/katacoda-gs-accessing"
+export CONTAINER="dvcorg/doc-katacoda:start-accessing"
 
 docker volume create example-get-started
 

--- a/get-started/04-stages/install.sh
+++ b/get-started/04-stages/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CONTAINER="emresult/katacoda-gs-stages"
+export CONTAINER="dvcorg/doc-katacoda:start-stages"
 
 docker volume create example-get-started
 

--- a/get-started/05-params-metrics-plots/install.sh
+++ b/get-started/05-params-metrics-plots/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CONTAINER="emresult/katacoda-gs-params"
+export CONTAINER="dvcorg/doc-katacoda:start-params"
 
 docker volume create example-get-started
 

--- a/get-started/06-experiments/install.sh
+++ b/get-started/06-experiments/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CONTAINER="emresult/katacoda-gs-experiments"
+export CONTAINER="dvcorg/doc-katacoda:start-experiments"
 
 docker volume create example-get-started
 


### PR DESCRIPTION
This one renames containers from `emresult` versions to `dvcorg` versions as described in iterative/dvc-doc-containers#3

Closes #56